### PR TITLE
updating the temp workspace to use what should hopefully be static

### DIFF
--- a/.github/workflows/create-test-env.yml
+++ b/.github/workflows/create-test-env.yml
@@ -34,7 +34,7 @@ jobs:
           role-to-assume: ${{ secrets.TERRAFORM_BUILD_ROLE }}
           role-duration-seconds: 3600
       - name: Generate temporary worksapce ID
-        run: echo "::set-env name=ref_workspace::$(git name-rev HEAD --name-only | sha1sum | cut -d' ' -f1 | cut -c -10)"
+        run: echo "::set-env name=ref_workspace::$(echo ${{ github.ref }} | sha1sum | cut -d' ' -f1 | cut -c -10)"
       - name: Terraform Init
         uses: hashicorp/terraform-github-actions@master
         with:

--- a/.github/workflows/destroy-test-env.yml
+++ b/.github/workflows/destroy-test-env.yml
@@ -19,7 +19,7 @@ jobs:
           role-to-assume: ${{ secrets.TERRAFORM_BUILD_ROLE }}
           role-duration-seconds: 3600
       - name: Generate temporary worksapce ID
-        run: echo "::set-env name=ref_workspace::$(git name-rev HEAD --name-only | sha1sum | cut -d' ' -f1 | cut -c -10)"
+        run: echo "::set-env name=ref_workspace::$(echo ${{ github.ref }} | sha1sum | cut -d' ' -f1 | cut -c -10)"
       - name: Terraform Init
         uses: hashicorp/terraform-github-actions@master
         with:


### PR DESCRIPTION
Previously using `git name-rev` but that will have broken for a closed pull request, because that change belongs to master now. The PR ref should be static.